### PR TITLE
Update style import in Remix guide

### DIFF
--- a/docs/pages/guides/remix.mdx
+++ b/docs/pages/guides/remix.mdx
@@ -60,7 +60,7 @@ Add styles imports, [MantineProvider](/theming/mantine-provider/) and [ColorSche
 ```tsx
 // Import styles of packages that you've installed.
 // All packages except `@mantine/hooks` require styles imports
-import '@mantine/core/styles.css';
+import mantineCoreStyles from '@mantine/core/styles.css';
 
 import { cssBundleHref } from '@remix-run/css-bundle';
 import type { LinksFunction } from '@remix-run/node';
@@ -69,6 +69,7 @@ import { MantineProvider, ColorSchemeScript } from '@mantine/core';
 
 export const links: LinksFunction = () => [
   ...(cssBundleHref ? [{ rel: 'stylesheet', href: cssBundleHref }] : []),
+  { rel: "stylesheet", href: mantineCoreStyles },
 ];
 
 export default function App() {


### PR DESCRIPTION
When following the Remix guide, I get the following error when building the app
```
mantine-v7-remix-template git:(master) ✗ npm run build

> build
> remix build

Building Remix app in production mode...
The path "@mantine/core/styles.css?__remix_sideEffect__" is imported in  but "@mantine/core/styles.css?__remix_sideEffect__" was not found in your node_modules. Did you forget to install it?
Built in 833ms
```

The error goes away by importing the styles through a stylesheet link. I am no expert on the exact differences here, but compared the css output and it resulted in the same output.