### PR TITLE
Fix typo in Container.demo.usage.tsx

### DIFF
--- a/src/mantine-demos/src/demos/core/Container/Container.demo.usage.tsx
+++ b/src/mantine-demos/src/demos/core/Container/Container.demo.usage.tsx
@@ -20,7 +20,7 @@ function Demo() {
         xs Container
       </Container>
 
-      <Container px={0} size="30rem" {...demoProps} mt="md">
+      <Container px={0} size="30rem" {...demoProps}>
         30rem Container without padding
       </Container>
     </>


### PR DESCRIPTION
Remove explicit prop mt="md" as it already defined in defaultProps object.