### PR TITLE
broken link in 6x -> 7x guide

### DIFF
--- a/docs/pages/guides/6x-to-7x.mdx
+++ b/docs/pages/guides/6x-to-7x.mdx
@@ -18,7 +18,7 @@ Most notable parts:
 - [CSS variables](/styles/css-variables)
 - [data-\* attributes](/styles/data-attributes)
 - [Styles API](/styles/styles-api)
-- [Responsive styles](/styles/responsive-styles)
+- [Responsive styles](/styles/responsive)
 
 Note that this guide assumes that you have [postcss-preset-mantine](/styles/postcss-preset) installed and configured
 in your project.


### PR DESCRIPTION
The link in the migration guide is broke.