### PR TITLE
Add "module" for all package.json

### DIFF
--- a/src/mantine-carousel/package.json
+++ b/src/mantine-carousel/package.json
@@ -3,6 +3,7 @@
   "description": "Embla based carousel",
   "version": "7.0.0-beta.0",
   "types": "./lib/index.d.ts",
+  "module": "./esm/index.js",
   "exports": {
     ".": {
       "import": "./esm/index.js",

--- a/src/mantine-code-highlight/package.json
+++ b/src/mantine-code-highlight/package.json
@@ -3,6 +3,7 @@
   "description": "Code highlight with Mantine theme",
   "version": "7.0.0-beta.0",
   "types": "./lib/index.d.ts",
+  "module": "./esm/index.js",
   "exports": {
     ".": {
       "import": "./esm/index.js",

--- a/src/mantine-colors-generator/package.json
+++ b/src/mantine-colors-generator/package.json
@@ -2,6 +2,7 @@
   "name": "@mantine/colors-generator",
   "version": "7.0.0-beta.0",
   "types": "./lib/index.d.ts",
+  "module": "./esm/index.js",
   "exports": {
     ".": {
       "import": "./esm/index.js",

--- a/src/mantine-core/package.json
+++ b/src/mantine-core/package.json
@@ -3,6 +3,7 @@
   "description": "React components library focused on usability, accessibility and developer experience",
   "version": "7.0.0-beta.0",
   "types": "./lib/index.d.ts",
+  "module": "./esm/index.js",
   "exports": {
     ".": {
       "import": "./esm/index.js",

--- a/src/mantine-dates-tests/package.json
+++ b/src/mantine-dates-tests/package.json
@@ -3,6 +3,7 @@
   "private": true,
   "version": "7.0.0-beta.0",
   "types": "./lib/index.d.ts",
+  "module": "./esm/index.js",
   "exports": {
     ".": {
       "import": "./esm/index.js",

--- a/src/mantine-dates/package.json
+++ b/src/mantine-dates/package.json
@@ -3,6 +3,7 @@
   "description": "Calendars, date and time pickers based on Mantine components",
   "version": "7.0.0-beta.0",
   "types": "./lib/index.d.ts",
+  "module": "./esm/index.js",
   "exports": {
     ".": {
       "import": "./esm/index.js",

--- a/src/mantine-demos/package.json
+++ b/src/mantine-demos/package.json
@@ -4,6 +4,7 @@
   "private": true,
   "version": "7.0.0-beta.0",
   "types": "./lib/index.d.ts",
+  "module": "./esm/index.js",
   "exports": {
     ".": {
       "import": "./esm/index.js",

--- a/src/mantine-dropzone/package.json
+++ b/src/mantine-dropzone/package.json
@@ -3,6 +3,7 @@
   "description": "Dropzone component built with Mantine theme and components",
   "version": "7.0.0-beta.0",
   "types": "./lib/index.d.ts",
+  "module": "./esm/index.js",
   "exports": {
     ".": {
       "import": "./esm/index.js",

--- a/src/mantine-ds/package.json
+++ b/src/mantine-ds/package.json
@@ -3,6 +3,7 @@
   "description": "Internal Mantine components used on *.mantine.dev websites",
   "version": "7.0.0-beta.0",
   "types": "./lib/index.d.ts",
+  "module": "./esm/index.js",
   "exports": {
     ".": {
       "import": "./esm/index.js",

--- a/src/mantine-form/package.json
+++ b/src/mantine-form/package.json
@@ -3,6 +3,7 @@
   "description": "Mantine form management library",
   "version": "7.0.0-beta.0",
   "types": "./lib/index.d.ts",
+  "module": "./esm/index.js",
   "exports": {
     ".": {
       "import": "./esm/index.js",

--- a/src/mantine-hooks/package.json
+++ b/src/mantine-hooks/package.json
@@ -2,6 +2,7 @@
   "name": "@mantine/hooks",
   "version": "7.0.0-beta.0",
   "types": "./lib/index.d.ts",
+  "module": "./esm/index.js",
   "exports": {
     ".": {
       "import": "./esm/index.js",

--- a/src/mantine-modals/package.json
+++ b/src/mantine-modals/package.json
@@ -3,6 +3,7 @@
   "description": "Modals manager based on Mantine components",
   "version": "7.0.0-beta.0",
   "types": "./lib/index.d.ts",
+  "module": "./esm/index.js",
   "exports": {
     ".": {
       "import": "./esm/index.js",

--- a/src/mantine-notifications/package.json
+++ b/src/mantine-notifications/package.json
@@ -2,6 +2,7 @@
   "name": "@mantine/notifications",
   "version": "7.0.0-beta.0",
   "types": "./lib/index.d.ts",
+  "module": "./esm/index.js",
   "exports": {
     ".": {
       "import": "./esm/index.js",

--- a/src/mantine-nprogress/package.json
+++ b/src/mantine-nprogress/package.json
@@ -3,6 +3,7 @@
   "description": "Navigation progress bar",
   "version": "7.0.0-beta.0",
   "types": "./lib/index.d.ts",
+  "module": "./esm/index.js",
   "exports": {
     ".": {
       "import": "./esm/index.js",

--- a/src/mantine-spotlight/package.json
+++ b/src/mantine-spotlight/package.json
@@ -2,6 +2,7 @@
   "name": "@mantine/spotlight",
   "version": "7.0.0-beta.0",
   "types": "./lib/index.d.ts",
+  "module": "./esm/index.js",
   "exports": {
     ".": {
       "import": "./esm/index.js",

--- a/src/mantine-store/package.json
+++ b/src/mantine-store/package.json
@@ -2,6 +2,7 @@
   "name": "@mantine/store",
   "version": "7.0.0-beta.0",
   "types": "./lib/index.d.ts",
+  "module": "./esm/index.js",
   "exports": {
     ".": {
       "import": "./esm/index.js",

--- a/src/mantine-styles-api/package.json
+++ b/src/mantine-styles-api/package.json
@@ -4,6 +4,7 @@
   "private": true,
   "version": "7.0.0-beta.0",
   "types": "./lib/index.d.ts",
+  "module": "./esm/index.js",
   "exports": {
     ".": {
       "import": "./esm/index.js",

--- a/src/mantine-tests/package.json
+++ b/src/mantine-tests/package.json
@@ -3,6 +3,7 @@
   "private": true,
   "version": "7.0.0-beta.0",
   "types": "./lib/index.d.ts",
+  "module": "./esm/index.js",
   "exports": {
     ".": {
       "import": "./esm/index.js",

--- a/src/mantine-tiptap/package.json
+++ b/src/mantine-tiptap/package.json
@@ -3,6 +3,7 @@
   "description": "Rich text editor based on tiptap",
   "version": "7.0.0-beta.0",
   "types": "./lib/index.d.ts",
+  "module": "./esm/index.js",
   "exports": {
     ".": {
       "import": "./esm/index.js",

--- a/src/mantine-vanilla-extract/package.json
+++ b/src/mantine-vanilla-extract/package.json
@@ -2,6 +2,7 @@
   "name": "@mantine/vanilla-extract",
   "version": "7.0.0-beta.0",
   "types": "./lib/index.d.ts",
+  "module": "./esm/index.js",
   "exports": {
     ".": {
       "import": "./esm/index.js",


### PR DESCRIPTION
Missing "module" field causes packers, such as parcel, to fail to import. 