### PR TITLE
[@mantine/notifications] Notifications: invalid reference in dependence array

### DIFF
--- a/src/mantine-notifications/src/Notifications.tsx
+++ b/src/mantine-notifications/src/Notifications.tsx
@@ -187,7 +187,7 @@ export const Notifications = factory<NotificationsFactory>((_props, ref) => {
       setTimeout(() => forceUpdate(), 0);
     }
     previousLength.current = data.notifications.length;
-  }, [notifications]);
+  }, [data.notifications]);
 
   const items = data.notifications.map((notification) => (
     <Transition


### PR DESCRIPTION
fix: https://github.com/mantinedev/mantine-v7/issues/18 
Invalid deps array in useDidUpdate so it dosnt even run 