### PR TITLE
Fix typo

### DIFF
--- a/scripts/docgen.ts
+++ b/scripts/docgen.ts
@@ -105,7 +105,7 @@ const EXTRA_FILES_PATHS = [
 
   // Dropzone
   '../src/mantine-dropzone/src/Dropzone.tsx',
-  '../src/mantine-dropzone/src/DropzoneFullscreen.tsx',
+  '../src/mantine-dropzone/src/DropzoneFullScreen.tsx',
 
   // CodeHighlight
   '../src/mantine-code-highlight/src/CodeHighlight.tsx',


### PR DESCRIPTION
there was a typo in the docgen.ts file that caused the script fail

![image](https://github.com/mantinedev/mantine-v7/assets/14942614/fed71ba5-39e6-484f-9a6f-1211459563f0)
