### PR TITLE
[@mantine/vanilla-extract] theme-to-vars: Fix headings' vars

### DIFF
--- a/src/mantine-vanilla-extract/src/theme-to-vars.ts
+++ b/src/mantine-vanilla-extract/src/theme-to-vars.ts
@@ -39,7 +39,7 @@ export function themeToVars(theme: MantineThemeOverride): MantineVars {
   const radius = getSizesVariables<Radius>(mergedTheme, 'radius', 'radius');
   const spacing = getSizesVariables<Spacing>(mergedTheme, 'spacing', 'spacing');
 
-  const headings = Object.keys(mergedTheme.headings).reduce(
+  const headings = Object.keys(mergedTheme.headings.sizes).reduce(
     (acc: Record<string, Heading>, heading) => {
       acc[heading] = {
         fontSize: `var(--mantine-${heading}-font-size)`,


### PR DESCRIPTION
Generated CSS Variables about `headings` by theme-to-vars were unintended values are follows
Because the keys of mergedTheme.headings) are not h1 ~ h6, but `fontFamily`, `fontWeight`, `sizes`.


```js
{
  fontFamily: {
    fontSize: 'var(--mantine-fontFamily-font-size)',
    lineHeight: 'var(--mantine-fontFamily-line-height)',
    fontWeight: 'var(--mantine-fontFamily-font-weight)'
  },
  fontWeight: {
    fontSize: 'var(--mantine-fontWeight-font-size)',
    lineHeight: 'var(--mantine-fontWeight-line-height)',
    fontWeight: 'var(--mantine-fontWeight-font-weight)'
  },
  sizes: {
    fontSize: 'var(--mantine-sizes-font-size)',
    lineHeight: 'var(--mantine-sizes-line-height)',
    fontWeight: 'var(--mantine-sizes-font-weight)'
  }
},
{
  fontFamily: {
    fontSize: 'var(--mantine-fontFamily-font-size)',
    lineHeight: 'var(--mantine-fontFamily-line-height)',
    fontWeight: 'var(--mantine-fontFamily-font-weight)'
  },
  fontWeight: {
    fontSize: 'var(--mantine-fontWeight-font-size)',
    lineHeight: 'var(--mantine-fontWeight-line-height)',
    fontWeight: 'var(--mantine-fontWeight-font-weight)'
  },
  sizes: {
    fontSize: 'var(--mantine-sizes-font-size)',
    lineHeight: 'var(--mantine-sizes-line-height)',
    fontWeight: 'var(--mantine-sizes-font-weight)'
  }
},
{
  fontFamily: {
    fontSize: 'var(--mantine-fontFamily-font-size)',
    lineHeight: 'var(--mantine-fontFamily-line-height)',
    fontWeight: 'var(--mantine-fontFamily-font-weight)'
  },
  fontWeight: {
    fontSize: 'var(--mantine-fontWeight-font-size)',
    lineHeight: 'var(--mantine-fontWeight-line-height)',
    fontWeight: 'var(--mantine-fontWeight-font-weight)'
  },
  sizes: {
    fontSize: 'var(--mantine-sizes-font-size)',
    lineHeight: 'var(--mantine-sizes-line-height)',
    fontWeight: 'var(--mantine-sizes-font-weight)'
  }
}
```

So I have fixed this problem.